### PR TITLE
Added ability to clear and set a project template specifically

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ upload-project --tenant "QA Infra" --project "Deploy API" --variableType Environ
 -f "C:\QA\appsettings.json" -e QA RC
 ```
 
+#### Targeting a Project Template
+
+This command takes the variables from the json file and creates project variable templates in the specified project.
+Variables that are not secret are created using their values in the json file as the default value.
+Variables that are secret are given no default value.
+
+Targeting a project has one additional argument
+
+- `-p`, `--project`
+  - The Octopus project to match Tenant variables with
+
+Targeting a project also has one optional argument
+
+- `-c`, `--clear`
+  - Clears the previous template before uploading new template
+
+Example:
+
+```bash
+upload-project-template --project "Deploy API" --variableType JsonConversion \
+-a "API-KEY" -p "API_" --vaultUri "http://vaultapi:8200" \
+--vaultRole "VAULT_PROVIDED_ROLE_GUID" --secret "VAULT_PROVIDED_ROLE_SECRET_GUID" \
+-f "C:\QA\appsettings.json" ---clear
+```
+
+
 #### Clearing a Project of Variable Templates
 
 Deletes **ALL** the variables templates in the specified project

--- a/README.md
+++ b/README.md
@@ -354,6 +354,30 @@ void ClearTenantConfig(string octoApiUri, string octoApiKey, string vaultUri, st
     ClearTenantConfig(new TenantTargetArgs(){ ... });
 }
 
+
+```
+#### Cake Project Targets
+
+```csharp
+void UploadProjectJson(string octoApiUri, string octoApiKey, string vaultUri, string vaultRoleId, string vaultSecretId,
+    List<string> enviros, List<string> roles, string project, string filePath, string prefix, bool clear)
+{
+    Information($"Uploading {filePath}");
+    UploadProject(new UploadProjectArgs(){
+        File = filePath,
+        ApiKey = octoApiKey,
+        OctoUri = octoApiUri,
+        ProjectName = project,
+        Environments = enviros,
+        OctoRoles =  roles,
+        VaultUri = vaultUri,
+        VaultRoleId = vaultRoleId,
+        VaultSecretId = vaultSecretId,
+        VariableType = VariableType.JsonConversion,
+        Clear = clear
+    });
+}
+
 void ClearProjectConfig(string octoApiUri, string octoApiKey, string vaultUri, string vaultRoleId, string vaultSecretId,
     List<string> enviros, List<string> roles, string tenant, string project, string filePath)
 {
@@ -361,7 +385,6 @@ void ClearProjectConfig(string octoApiUri, string octoApiKey, string vaultUri, s
     ClearProjectConfig(new TenantTargetArgs(){ ... });
 }
 ```
-
 #### Deprecated Cake Targets
 
 ```csharp

--- a/src/OctoConfig.Core/Arguments/ArgsBase.cs
+++ b/src/OctoConfig.Core/Arguments/ArgsBase.cs
@@ -18,6 +18,17 @@ namespace OctoConfig.Core.Arguments
 		public bool MergeArrays { get; set; }
 	}
 
+	public interface IProjectArgsBase
+	{
+		string ProjectName { get; set; }
+	}
+
+	public class ProjectArgsBase : ArgsBase, IProjectArgsBase
+	{
+		[Option('p', "project", Required = true, HelpText = "The Octopus project to match variables with")]
+		public string ProjectName { get; set; }
+	}
+
 	public class FileArgsBase : ArgsBase
 	{
 		[Option('f', "file", Required = true, HelpText = "The json file to parse into variables")]

--- a/src/OctoConfig.Core/Arguments/ClearArgs.cs
+++ b/src/OctoConfig.Core/Arguments/ClearArgs.cs
@@ -8,11 +8,7 @@ namespace OctoConfig.Core.Arguments
 	}
 
 	[Verb("clear-project", HelpText = "Removes ALL the variable templates in the specified project")]
-	public class ClearProjectArgs : ArgsBase
-	{
-		[Option('p', "project", Required = true, HelpText = "The Octopus role(s) to scope variables to")]
-		public string ProjectName { get; set; }
-	}
+	public class ClearProjectArgs : ProjectArgsBase { }
 
 	[Verb("clear-tenant", HelpText = "Removes ALL the variables in the specified tenant")]
 	public class ClearTenantArgs : ArgsBase

--- a/src/OctoConfig.Core/Arguments/ProjectTargetArgs.cs
+++ b/src/OctoConfig.Core/Arguments/ProjectTargetArgs.cs
@@ -1,0 +1,10 @@
+﻿using CommandLine;
+
+namespace OctoConfig.Core.Arguments
+{
+	public class ProjectTargetArgs : FileArgsBase, IProjectArgsBase
+	{
+		[Option('p', "project", Required = true, HelpText = "The Octopus project to match variables with")]
+		public string ProjectName { get; set; }
+	}
+}

--- a/src/OctoConfig.Core/Arguments/TenantTargetArgs.cs
+++ b/src/OctoConfig.Core/Arguments/TenantTargetArgs.cs
@@ -3,12 +3,9 @@
 namespace OctoConfig.Core.Arguments
 {
 	[Verb("upload-project", HelpText = "Convert json file to environment variables and upload them to Octopus")]
-	public class TenantTargetArgs : FileArgsBase
+	public class TenantTargetArgs : ProjectTargetArgs
 	{
 		[Option('t', "tenant", Required = true, HelpText = "The Octopus tenant to attach variables to")]
 		public string TenantName { get; set; }
-
-		[Option('p', "project", Required = true, HelpText = "The Octopus project to match tenant variables with")]
-		public string ProjectName { get; set; }
 	}
 }

--- a/src/OctoConfig.Core/Arguments/UploadProjectArgs.cs
+++ b/src/OctoConfig.Core/Arguments/UploadProjectArgs.cs
@@ -2,7 +2,7 @@
 
 namespace OctoConfig.Core.Arguments
 {
-	[Verb("upload-project-template", HelpText = "Convert json file to environment variables and upload them to Octopus")]
+	[Verb("upload-project-template", HelpText = "Upload them to an Octopus project as templates")]
 	public sealed class UploadProjectArgs : ProjectTargetArgs
 	{
 		[Option('c', "clear", Required = false, Default = false, HelpText = "Clears any project variables in the project before uploading new template")]

--- a/src/OctoConfig.Core/Arguments/UploadProjectArgs.cs
+++ b/src/OctoConfig.Core/Arguments/UploadProjectArgs.cs
@@ -1,0 +1,11 @@
+﻿using CommandLine;
+
+namespace OctoConfig.Core.Arguments
+{
+	[Verb("upload-project-template", HelpText = "Convert json file to environment variables and upload them to Octopus")]
+	public sealed class UploadProjectArgs : ProjectTargetArgs
+	{
+		[Option('c', "clear", Required = false, Default = false, HelpText = "Clears any project variables in the project before uploading new template")]
+		public bool ClearProject { get; set; }
+	}
+}

--- a/src/OctoConfig.Core/Cake/CakeAliases.cs
+++ b/src/OctoConfig.Core/Cake/CakeAliases.cs
@@ -70,6 +70,14 @@ namespace OctoConfig.Cake
 		}
 
 		[CakeMethodAlias]
+		public static void UploadProject(this ICakeContext context, UploadProjectArgs args)
+		{
+			DependencyConfig.Setup(args, context).GetAwaiter().GetResult();
+			var cmd = DependencyConfig.Container.GetService<UploadProjectCommand>();
+			cmd.Execute().GetAwaiter().GetResult();
+		}
+
+		[CakeMethodAlias]
 		public static void ValidateTenantConfig(this ICakeContext context, ValidateTenantArgs args)
 		{
 			DependencyConfig.Setup(args, context).GetAwaiter().GetResult();

--- a/src/OctoConfig.Core/Commands/ClearProjectCommand.cs
+++ b/src/OctoConfig.Core/Commands/ClearProjectCommand.cs
@@ -6,9 +6,9 @@ namespace OctoConfig.Core.Commands
 {
 	public class ClearProjectCommand
 	{
-		private readonly ProjectClearer _projectClearer;
+		private readonly IProjectClearer _projectClearer;
 
-		public ClearProjectCommand(ProjectClearer projectClearer)
+		public ClearProjectCommand(IProjectClearer projectClearer)
 		{
 			_projectClearer = projectClearer ?? throw new System.ArgumentNullException(nameof(projectClearer));
 		}

--- a/src/OctoConfig.Core/Commands/ClearTenantCommand.cs
+++ b/src/OctoConfig.Core/Commands/ClearTenantCommand.cs
@@ -6,9 +6,9 @@ namespace OctoConfig.Core.Commands
 {
 	public class ClearTenantCommand
 	{
-		private readonly TenantClearer _tenantClearer;
+		private readonly ITenantClearer _tenantClearer;
 
-		public ClearTenantCommand(TenantClearer tenantClearer)
+		public ClearTenantCommand(ITenantClearer tenantClearer)
 		{
 			_tenantClearer = tenantClearer ?? throw new System.ArgumentNullException(nameof(tenantClearer));
 		}

--- a/src/OctoConfig.Core/Commands/UploadProjectCommand.cs
+++ b/src/OctoConfig.Core/Commands/UploadProjectCommand.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OctoConfig.Core.Arguments;
+using OctoConfig.Core.Converter;
+using OctoConfig.Core.Octopus;
+using OctoConfig.Core.Secrets;
+
+namespace OctoConfig.Core.Commands
+{
+	public class UploadProjectCommand
+	{
+		private readonly UploadProjectArgs _args;
+		private readonly ISecretsMananger _secretsMananger;
+		private readonly VariableConverter _varConverter;
+		private readonly ProjectManager _projectManager;
+		private readonly ProjectClearer _projectClearer;
+
+		public UploadProjectCommand(UploadProjectArgs args, ISecretsMananger secretsMananger, ProjectManager projectManager,
+			ProjectClearer projectClearer, VariableConverter variableConverter)
+		{
+			_args = args ?? throw new ArgumentNullException(nameof(args));
+			_secretsMananger = secretsMananger ?? throw new ArgumentNullException(nameof(secretsMananger));
+			_varConverter = variableConverter ?? throw new ArgumentNullException(nameof(variableConverter));
+			_projectManager = projectManager ?? throw new ArgumentNullException(nameof(projectManager));
+			_projectClearer = projectClearer ?? throw new ArgumentNullException(nameof(projectClearer));
+		}
+
+		public async Task Execute()
+		{
+			var vars = _varConverter.Convert(File.ReadAllText(_args.File));
+			if(_args.ClearProject)
+			{
+				await _projectClearer.ClearProjectVariables();
+			}
+			await _secretsMananger.ReplaceSecrets(vars).ConfigureAwait(false);
+			await _projectManager.CreateProjectVariables(vars, true);
+
+			var secretCount = vars.Count(s => s.IsSecret);
+			var pub = vars.Count - secretCount;
+			Console.WriteLine($"Found a total of {vars.Count} variables.");
+			Console.WriteLine($"{secretCount} were secrets and {pub} were not");
+		}
+	}
+}

--- a/src/OctoConfig.Core/DependencySetup/DependencyConfig.cs
+++ b/src/OctoConfig.Core/DependencySetup/DependencyConfig.cs
@@ -80,6 +80,7 @@ namespace OctoConfig.Core.DependencySetup
 			coll.AddSingleton<ClearTenantCommand>();
 			coll.AddSingleton<ClearProjectCommand>();
 			coll.AddSingleton<ValidateTenantCommand>();
+			coll.AddSingleton<UploadProjectCommand>();
 			Container = coll.BuildServiceProvider();
 		}
 
@@ -93,6 +94,15 @@ namespace OctoConfig.Core.DependencySetup
 			if(args is LibraryTargetArgs lArgs)
 			{
 				coll.AddSingleton(lArgs);
+			}
+			if (args is ProjectTargetArgs ptArgs)
+			{
+				coll.AddSingleton(ptArgs);
+				coll.AddSingleton<IProjectArgsBase>(new ProjectArgsBase { ProjectName = ptArgs.ProjectName });
+			}
+			if (args is ProjectArgsBase pbArgs)
+			{
+				coll.AddSingleton(pbArgs);
 			}
 			switch (args)
 			{
@@ -114,6 +124,9 @@ namespace OctoConfig.Core.DependencySetup
 					break;
 				case TenantTargetArgs pAgs:
 					coll.AddSingleton(pAgs);
+					break;
+				case UploadProjectArgs upArgs:
+					coll.AddSingleton(upArgs);
 					break;
 				default:
 					throw new ArgumentException($"Unknown argument type '{args.GetType()}'", nameof(args));

--- a/src/OctoConfig.Core/DependencySetup/DependencyConfig.cs
+++ b/src/OctoConfig.Core/DependencySetup/DependencyConfig.cs
@@ -25,7 +25,7 @@ namespace OctoConfig.Core.DependencySetup
 			{
 				throw new ArgumentException("Null or empty Octopus Deploy API URI", nameof(args.OctoUri));
 			}
-			if (String.IsNullOrEmpty(args.ApiKey))
+			if(String.IsNullOrEmpty(args.ApiKey))
 			{
 				throw new ArgumentException("Null or empty Octopus Deploy API key", nameof(args.ApiKey));
 			}
@@ -68,8 +68,8 @@ namespace OctoConfig.Core.DependencySetup
 
 			coll.AddSingleton<ILibraryManager, LibraryManager>();
 			coll.AddSingleton<IProjectManager, ProjectManager>();
-			coll.AddSingleton<ProjectClearer>();
-			coll.AddSingleton<TenantClearer>();
+			coll.AddSingleton<IProjectClearer, ProjectClearer>();
+			coll.AddSingleton<ITenantClearer, TenantClearer>();
 			coll.AddSingleton<ITenantManager, TenantManager>();
 			coll.AddSingleton<VariableConverter>();
 
@@ -122,11 +122,11 @@ namespace OctoConfig.Core.DependencySetup
 					coll.AddSingleton(vtArgs);
 					coll.AddSingleton<TenantTargetArgs>(vtArgs);
 					break;
-				case TenantTargetArgs pAgs:
-					coll.AddSingleton(pAgs);
-					break;
 				case UploadProjectArgs upArgs:
 					coll.AddSingleton(upArgs);
+					break;
+				case TenantTargetArgs pAgs:
+					coll.AddSingleton(pAgs);
 					break;
 				default:
 					throw new ArgumentException($"Unknown argument type '{args.GetType()}'", nameof(args));

--- a/src/OctoConfig.Core/Octopus/ProjectClearer.cs
+++ b/src/OctoConfig.Core/Octopus/ProjectClearer.cs
@@ -5,7 +5,11 @@ using Octopus.Client;
 
 namespace OctoConfig.Core.Octopus
 {
-	public class ProjectClearer
+	public interface IProjectClearer
+	{
+		Task ClearProjectVariables();
+	}
+	public class ProjectClearer : IProjectClearer
 	{
 		private readonly IProjectArgsBase _args;
 		private readonly IOctopusAsyncRepository _octopusRepository;

--- a/src/OctoConfig.Core/Octopus/ProjectClearer.cs
+++ b/src/OctoConfig.Core/Octopus/ProjectClearer.cs
@@ -7,10 +7,10 @@ namespace OctoConfig.Core.Octopus
 {
 	public class ProjectClearer
 	{
-		private readonly ClearProjectArgs _args;
+		private readonly IProjectArgsBase _args;
 		private readonly IOctopusAsyncRepository _octopusRepository;
 
-		public ProjectClearer(ClearProjectArgs args, IOctopusAsyncRepository octopusRepository)
+		public ProjectClearer(IProjectArgsBase args, IOctopusAsyncRepository octopusRepository)
 		{
 			_args = args ?? throw new ArgumentNullException(nameof(args));
 			_octopusRepository = octopusRepository ?? throw new ArgumentNullException(nameof(octopusRepository));

--- a/src/OctoConfig.Core/Octopus/ProjectManager.cs
+++ b/src/OctoConfig.Core/Octopus/ProjectManager.cs
@@ -15,12 +15,12 @@ namespace OctoConfig.Core.Octopus
 
 	public class ProjectManager : IProjectManager
 	{
-		private readonly ProjectArgsBase _args;
+		private readonly IProjectArgsBase _args;
 		private readonly IOctopusAsyncRepository _octopusRepository;
 		private readonly ILogger _logger;
 		private static readonly string _placeholder = "PLACEHOLDER_VALUE";
 
-		public ProjectManager(ProjectArgsBase args, IOctopusAsyncRepository octopusRepository, ILogger logger)
+		public ProjectManager(IProjectArgsBase args, IOctopusAsyncRepository octopusRepository, ILogger logger)
 		{
 			_args = args ?? throw new ArgumentNullException(nameof(args));
 			_octopusRepository = octopusRepository ?? throw new ArgumentNullException(nameof(octopusRepository));

--- a/src/OctoConfig.Core/Octopus/ProjectManager.cs
+++ b/src/OctoConfig.Core/Octopus/ProjectManager.cs
@@ -10,23 +10,24 @@ namespace OctoConfig.Core.Octopus
 {
 	public interface IProjectManager
 	{
-		Task CreateProjectVariables(List<SecretVariable> vars);
+		Task CreateProjectVariables(List<SecretVariable> vars, bool useValue = false);
 	}
 
 	public class ProjectManager : IProjectManager
 	{
-		private readonly TenantTargetArgs _args;
+		private readonly ProjectArgsBase _args;
 		private readonly IOctopusAsyncRepository _octopusRepository;
 		private readonly ILogger _logger;
+		private static readonly string _placeholder = "PLACEHOLDER_VALUE";
 
-		public ProjectManager(TenantTargetArgs args, IOctopusAsyncRepository octopusRepository, ILogger logger)
+		public ProjectManager(ProjectArgsBase args, IOctopusAsyncRepository octopusRepository, ILogger logger)
 		{
 			_args = args ?? throw new ArgumentNullException(nameof(args));
 			_octopusRepository = octopusRepository ?? throw new ArgumentNullException(nameof(octopusRepository));
 			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
 		}
 
-		public async Task CreateProjectVariables(List<SecretVariable> vars)
+		public async Task CreateProjectVariables(List<SecretVariable> vars, bool useValue = false)
 		{
 			var project = await _octopusRepository.ValidateProject(_args.ProjectName).ConfigureAwait(false);
 			var before = project.Templates.Count;
@@ -39,7 +40,8 @@ namespace OctoConfig.Core.Octopus
 				}
 				else
 				{
-					project.AddOrUpdateSingleLineTextTemplate(variable.Name, variable.Name, "PLACEHOLDER_VALUE", variable.Name);
+					var value = useValue ? variable.Value : _placeholder;
+					project.AddOrUpdateSingleLineTextTemplate(variable.Name, variable.Name, value, variable.Name);
 				}
 			}
 			var after = project.Templates.Count;

--- a/src/OctoConfig.Core/SecretVariable.cs
+++ b/src/OctoConfig.Core/SecretVariable.cs
@@ -11,6 +11,7 @@
 		public string Name { get; set; }
 		public string Value { get; set; }
 		public bool IsSecret { get; set; } = false;
+		public string DefaultValue { get; set; } = "PLACEHOLDER_VALUE";
 
 		public override string ToString()
 		{

--- a/src/OctoConfig.Core/SecretVariable.cs
+++ b/src/OctoConfig.Core/SecretVariable.cs
@@ -11,8 +11,6 @@
 		public string Name { get; set; }
 		public string Value { get; set; }
 		public bool IsSecret { get; set; } = false;
-		public string DefaultValue { get; set; } = "PLACEHOLDER_VALUE";
-
 		public override string ToString()
 		{
 			return $"{Name}={Value}";

--- a/src/OctoConfigTool/Program.cs
+++ b/src/OctoConfigTool/Program.cs
@@ -11,8 +11,8 @@ namespace OctopusConfigTool
 	{
 		public static async Task<int> Main(string[] cmdArgs)
 		{
-			return await Parser.Default.ParseArguments<ValidateArgs, ClearVariableSetArgs, LibraryTargetArgs, ValidateTenantArgs, TenantTargetArgs, ClearProjectArgs, ClearTenantArgs>(cmdArgs)
-				.MapResult<ValidateArgs, ClearVariableSetArgs, LibraryTargetArgs, ValidateTenantArgs, TenantTargetArgs, ClearProjectArgs, ClearTenantArgs, Task<int>>(
+			return await Parser.Default.ParseArguments<ValidateArgs, ClearVariableSetArgs, LibraryTargetArgs, ValidateTenantArgs, TenantTargetArgs, UploadProjectArgs, ClearProjectArgs, ClearTenantArgs>(cmdArgs)
+				.MapResult<ValidateArgs, ClearVariableSetArgs, LibraryTargetArgs, ValidateTenantArgs, TenantTargetArgs, UploadProjectArgs, ClearProjectArgs, ClearTenantArgs, Task<int>>(
 				async validateArgs =>
 				{
 					await DependencyConfig.Setup(validateArgs).ConfigureAwait(false);
@@ -45,6 +45,13 @@ namespace OctopusConfigTool
 				{
 					await DependencyConfig.Setup(uploadTenantArgs).ConfigureAwait(false);
 					var cmd = DependencyConfig.Container.GetService<UploadTenantCommand>();
+					await cmd.Execute().ConfigureAwait(false);
+					return 0;
+				},
+				async uploadProjectArgs =>
+				{
+					await DependencyConfig.Setup(uploadProjectArgs).ConfigureAwait(false);
+					var cmd = DependencyConfig.Container.GetService<UploadProjectCommand>();
 					await cmd.Execute().ConfigureAwait(false);
 					return 0;
 				},

--- a/test/OctoConfig.Tests/ProjectManagerTests.cs
+++ b/test/OctoConfig.Tests/ProjectManagerTests.cs
@@ -25,7 +25,7 @@ namespace OctoConfig.Tests
 		public void MissingProjectThrows(string projectName, [Frozen] Mock<IOctopusAsyncRepository> octoMoq)
 		{
 			octoMoq.Setup(o => o.Projects).Returns(Mock.Of<IProjectRepository>());
-			var args = new TenantTargetArgs() { ProjectName = projectName };
+			var args = new ProjectArgsBase() { ProjectName = projectName };
 			var sut = new ProjectManager(args, octoMoq.Object, Mock.Of<ILogger>());
 
 			Func<Task> test = () => sut.CreateProjectVariables(new List<SecretVariable>());
@@ -53,7 +53,7 @@ namespace OctoConfig.Tests
 				});
 			octoMoq.Setup(o => o.Projects).Returns(mockProj.Object);
 
-			var args = new TenantTargetArgs() { ProjectName = projectName };
+			var args = new ProjectArgsBase() { ProjectName = projectName };
 			var sut = new ProjectManager(args, octoMoq.Object, Mock.Of<ILogger>());
 
 			await sut.CreateProjectVariables(new List<SecretVariable>() { new SecretVariable(variableName, variableValue) }).ConfigureAwait(false);
@@ -80,7 +80,7 @@ namespace OctoConfig.Tests
 				});
 			octoMoq.Setup(o => o.Projects).Returns(mockProj.Object);
 
-			var args = new TenantTargetArgs() { ProjectName = projectName };
+			var args = new ProjectArgsBase() { ProjectName = projectName };
 			var sut = new ProjectManager(args, octoMoq.Object, Mock.Of<ILogger>());
 
 			await sut.CreateProjectVariables(new List<SecretVariable>() { new SecretVariable(variableName, variableValue) { IsSecret = true } }).ConfigureAwait(false);

--- a/test/OctoConfig.Tests/UploadProjectCommandTests.cs
+++ b/test/OctoConfig.Tests/UploadProjectCommandTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.Idioms;
+using AutoFixture.Xunit2;
+using Moq;
+using OctoConfig.Core;
+using OctoConfig.Core.Arguments;
+using OctoConfig.Core.Commands;
+using OctoConfig.Core.Octopus;
+using OctoConfig.Core.Secrets;
+using OctoConfig.Tests.TestFixture;
+using Xunit;
+
+namespace OctoConfig.Tests
+{
+	public static class UploadProjectCommandTests
+	{
+		public class Constructor
+		{
+			[Theory, AppAutoData]
+			public void ConstructorGuardClauses(IFixture fixture)
+			{
+				var assertion = new GuardClauseAssertion(fixture);
+				assertion.Verify(typeof(UploadProjectCommand).GetConstructors());
+			}
+		}
+
+		public class Execute
+		{
+			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
+			public async Task ApplyIsSetToFalse(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
+				[Frozen] Mock<IProjectClearer> mockClearer, [Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
+			{
+				mockFileSystem.AddFile(args.File, new MockFileData(json));
+				await sut.Execute().ConfigureAwait(false);
+				mockClearer.Verify(m => m.ClearProjectVariables(), Times.Once);
+				mockSecret.Verify(m => m.ReplaceSecrets(It.IsAny<List<SecretVariable>>()), Times.Once);
+				mockProject.Verify(m => m.CreateProjectVariables(It.IsAny<List<SecretVariable>>(), true), Times.Once);
+			}
+
+			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
+			public async Task VariablesAreSetCorrectly(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
+				[Frozen] Mock<IProjectClearer> mockClearer, [Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
+			{
+				mockFileSystem.AddFile(args.File, new MockFileData(json));
+				await sut.Execute().ConfigureAwait(false);
+				if (args.ClearProject)
+				{
+					mockClearer.Verify(m => m.ClearProjectVariables(), Times.Once);
+				}
+				mockSecret.Verify(m => m.ReplaceSecrets(It.Is<List<SecretVariable>>(l => l.Count == 1)), Times.Once);
+				mockProject.Verify(m => m.CreateProjectVariables(It.Is<List<SecretVariable>>(l => l.Count == 1), true), Times.Once);
+			}
+
+			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
+			public async Task ProjectTemplateDoesNotClear(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
+				[Frozen] Mock<IProjectClearer> mockClearer, [Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
+			{
+				mockFileSystem.AddFile(args.File, new MockFileData(json));
+				await sut.Execute().ConfigureAwait(false);
+				if (args.ClearProject)
+				{
+					mockClearer.Verify(m => m.ClearProjectVariables(), Times.Once);
+				}
+				mockSecret.Verify(m => m.ReplaceSecrets(It.IsAny<List<SecretVariable>>()), Times.Once);
+				mockProject.Verify(m => m.CreateProjectVariables(It.IsAny<List<SecretVariable>>(), true), Times.Once);
+			}
+		}
+	}
+}

--- a/test/OctoConfig.Tests/UploadProjectCommandTests.cs
+++ b/test/OctoConfig.Tests/UploadProjectCommandTests.cs
@@ -30,19 +30,8 @@ namespace OctoConfig.Tests
 		public class Execute
 		{
 			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
-			public async Task ApplyIsSetToFalse(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
-				[Frozen] Mock<IProjectClearer> mockClearer, [Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
-			{
-				mockFileSystem.AddFile(args.File, new MockFileData(json));
-				await sut.Execute().ConfigureAwait(false);
-				mockClearer.Verify(m => m.ClearProjectVariables(), Times.Once);
-				mockSecret.Verify(m => m.ReplaceSecrets(It.IsAny<List<SecretVariable>>()), Times.Once);
-				mockProject.Verify(m => m.CreateProjectVariables(It.IsAny<List<SecretVariable>>(), true), Times.Once);
-			}
-
-			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
-			public async Task VariablesAreSetCorrectly(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
-				[Frozen] Mock<IProjectClearer> mockClearer, [Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
+			public async Task ProjectVariablesAreSetCorrectly(string json, [Frozen] Mock<ISecretsMananger> mockSecret, [Frozen] Mock<IProjectManager> mockProject,
+				[Frozen] MockFileSystem mockFileSystem, [Frozen] UploadProjectArgs args, UploadProjectCommand sut)
 			{
 				mockFileSystem.AddFile(args.File, new MockFileData(json));
 				await sut.Execute().ConfigureAwait(false);

--- a/test/OctoConfig.Tests/UploadTenantCommandTests.cs
+++ b/test/OctoConfig.Tests/UploadTenantCommandTests.cs
@@ -36,7 +36,7 @@ namespace OctoConfig.Tests
 				mockFileSystem.AddFile(args.File, new MockFileData(json));
 				await sut.Execute().ConfigureAwait(false);
 				mockSecret.Verify(m => m.ReplaceSecrets(It.IsAny<List<SecretVariable>>()), Times.Once);
-				mockProject.Verify(m => m.CreateProjectVariables(It.IsAny<List<SecretVariable>>()), Times.Once);
+				mockProject.Verify(m => m.CreateProjectVariables(It.IsAny<List<SecretVariable>>(), false), Times.Once);
 			}
 
 			[Theory, InlineAppAutoData("{ \"a\":\"b\" }")]
@@ -46,7 +46,7 @@ namespace OctoConfig.Tests
 				mockFileSystem.AddFile(args.File, new MockFileData(json));
 				await sut.Execute().ConfigureAwait(false);
 				mockSecret.Verify(m => m.ReplaceSecrets(It.Is<List<SecretVariable>>(l => l.Count == 1)), Times.Once);
-				mockProject.Verify(m => m.CreateProjectVariables(It.Is<List<SecretVariable>>(l => l.Count == 1)), Times.Once);
+				mockProject.Verify(m => m.CreateProjectVariables(It.Is<List<SecretVariable>>(l => l.Count == 1), false), Times.Once);
 			}
 		}
 	}

--- a/test/OctoConfig.Tests/UploadTenantCommandTests.cs
+++ b/test/OctoConfig.Tests/UploadTenantCommandTests.cs
@@ -20,7 +20,7 @@ namespace OctoConfig.Tests
 		public class Constructor
 		{
 			[Theory, AppAutoData]
-			public void ContsructorGuardClauses(IFixture fixture)
+			public void ConstructorGuardClauses(IFixture fixture)
 			{
 				var assertion = new GuardClauseAssertion(fixture);
 				assertion.Verify(typeof(UploadTenantCommand).GetConstructors());


### PR DESCRIPTION
Before, there was no way using this tool to update just a project template. This was always coupled with updating a tenant specifically.